### PR TITLE
Add host agent Swift program with launchd support

### DIFF
--- a/LaunchDaemons/com.example.hostagent.plist
+++ b/LaunchDaemons/com.example.hostagent.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.example.hostagent</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>/usr/local/bin/host-agent</string>
+        <string>--host-id</string>
+        <string>HOST_ID_PLACEHOLDER</string>
+        <string>--broker-url</string>
+        <string>BROKER_URL_PLACEHOLDER</string>
+        <string>--key-path</string>
+        <string>/usr/local/etc/host-agent.key</string>
+    </array>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>KeepAlive</key>
+    <true/>
+</dict>
+</plist>

--- a/host-agent/HostAgent.swift
+++ b/host-agent/HostAgent.swift
@@ -1,0 +1,136 @@
+import Foundation
+import Dispatch
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+struct HostAgentConfig {
+    let hostID: String
+    let brokerURL: URL
+    let keyPath: String
+}
+
+final class RemoteManagementMonitor {
+    private var timer: Timer?
+    private let interval: TimeInterval = 60
+
+    func start() {
+        timer = Timer.scheduledTimer(withTimeInterval: interval, repeats: true) { _ in
+            self.ensureRemoteManagementEnabled()
+        }
+        RunLoop.current.add(timer!, forMode: .default)
+        ensureRemoteManagementEnabled()
+    }
+
+    private func ensureRemoteManagementEnabled() {
+        let kickstart = "/System/Library/CoreServices/RemoteManagement/ARDAgent.app/Contents/Resources/kickstart"
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: kickstart)
+        process.arguments = ["-activate", "-configure", "-access", "-on", "-clientopts", "-setreqperm", "-reqperm", "no"]
+        do {
+            try process.run()
+            process.waitUntilExit()
+        } catch {
+            NSLog("Failed to enable Remote Management: \(error)")
+        }
+    }
+}
+
+final class BrokerConnection {
+    private let url: URL
+    private let session: URLSession
+    private var task: URLSessionWebSocketTask?
+
+    init(url: URL) {
+        self.url = url
+        self.session = URLSession(configuration: .default)
+    }
+
+    func connect(hostID: String, keyPath: String) {
+        task = session.webSocketTask(with: url)
+        task?.resume()
+        authenticate(hostID: hostID, keyPath: keyPath)
+        receive()
+    }
+
+    private func authenticate(hostID: String, keyPath: String) {
+        guard let data = FileManager.default.contents(atPath: keyPath),
+              let key = String(data: data, encoding: .utf8) else {
+            NSLog("Unable to read key at \(keyPath)")
+            return
+        }
+        let payload: [String: String] = ["host_id": hostID, "key": key.trimmingCharacters(in: .whitespacesAndNewlines)]
+        if let sendData = try? JSONSerialization.data(withJSONObject: payload, options: []) {
+            task?.send(.data(sendData)) { error in
+                if let error = error {
+                    NSLog("Failed to send auth: \(error)")
+                }
+            }
+        }
+    }
+
+    private func receive() {
+        task?.receive { [weak self] result in
+            switch result {
+            case .failure(let error):
+                NSLog("WebSocket receive error: \(error)")
+            case .success(let message):
+                switch message {
+                case .string(let text):
+                    NSLog("Received string: \(text)")
+                case .data(let data):
+                    NSLog("Received \(data.count) bytes")
+                @unknown default:
+                    break
+                }
+            }
+            self?.receive()
+        }
+    }
+}
+
+func parseArguments() -> HostAgentConfig? {
+    var hostID: String?
+    var brokerURL: URL?
+    var keyPath: String?
+
+    var iterator = CommandLine.arguments.dropFirst().makeIterator()
+    while let arg = iterator.next() {
+        switch arg {
+        case "--host-id":
+            hostID = iterator.next()
+        case "--broker-url":
+            if let urlString = iterator.next() {
+                brokerURL = URL(string: urlString)
+            }
+        case "--key-path":
+            keyPath = iterator.next()
+        default:
+            break
+        }
+    }
+
+    if let hostID = hostID, let brokerURL = brokerURL, let keyPath = keyPath {
+        return HostAgentConfig(hostID: hostID, brokerURL: brokerURL, keyPath: keyPath)
+    }
+
+    print("Usage: HostAgent --host-id <ID> --broker-url <URL> --key-path <PATH>")
+    return nil
+}
+
+let signalSource = DispatchSource.makeSignalSource(signal: SIGTERM, queue: .main)
+signal(SIGTERM, SIG_IGN)
+signalSource.setEventHandler {
+    exit(0)
+}
+signalSource.resume()
+
+if let config = parseArguments() {
+    let monitor = RemoteManagementMonitor()
+    monitor.start()
+
+    let broker = BrokerConnection(url: config.brokerURL)
+    broker.connect(hostID: config.hostID, keyPath: config.keyPath)
+
+    RunLoop.current.run()
+}

--- a/scripts/install_host_agent.sh
+++ b/scripts/install_host_agent.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+set -e
+
+BINARY_PATH=${1:-./host-agent/HostAgent}
+PLIST_SOURCE=LaunchDaemons/com.example.hostagent.plist
+DEST_DIR=/Library/LaunchDaemons
+BIN_DEST=/usr/local/bin/host-agent
+
+if [ ! -f "$BINARY_PATH" ]; then
+  echo "Binary not found at $BINARY_PATH" >&2
+  exit 1
+fi
+
+mkdir -p "$DEST_DIR"
+install -m 755 "$BINARY_PATH" "$BIN_DEST"
+install -m 644 "$PLIST_SOURCE" "$DEST_DIR/com.example.hostagent.plist"
+launchctl load "$DEST_DIR/com.example.hostagent.plist"
+
+echo "Host agent installed."


### PR DESCRIPTION
## Summary
- add HostAgent Swift tool with Remote Management monitoring and broker websocket connection
- provide launchd plist for automatic startup with RunAtLoad
- create installer script to deploy the binary and plist to system LaunchDaemons

## Testing
- `swiftc host-agent/HostAgent.swift -o host-agent/HostAgent`
- `bash -n scripts/install_host_agent.sh`

------
https://chatgpt.com/codex/tasks/task_e_689b07f813c483299217d503e247df60