### PR TITLE
Add SwiftUI client scaffolding

### DIFF
--- a/client/.gitignore
+++ b/client/.gitignore
@@ -1,0 +1,8 @@
+.DS_Store
+/.build
+/Packages
+xcuserdata/
+DerivedData/
+.swiftpm/configuration/registries.json
+.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+.netrc

--- a/client/Package.swift
+++ b/client/Package.swift
@@ -1,0 +1,23 @@
+// swift-tools-version: 6.1
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "ClientApp",
+    platforms: [
+        .macOS(.v13)
+    ],
+    products: [
+        .executable(name: "ClientApp", targets: ["ClientApp"])
+    ],
+    dependencies: [
+        // Dependencies for WebRTC or SSH tunnels would be declared here.
+    ],
+    targets: [
+        .executableTarget(
+            name: "ClientApp",
+            dependencies: []
+        )
+    ]
+)

--- a/client/Sources/ClientApp/ClientApp.swift
+++ b/client/Sources/ClientApp/ClientApp.swift
@@ -1,0 +1,17 @@
+import SwiftUI
+
+@main
+struct ClientApp: App {
+    @StateObject private var session = RemoteSession()
+
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+                .environmentObject(session)
+        }
+        Settings {
+            PreferencesView()
+                .environmentObject(session)
+        }
+    }
+}

--- a/client/Sources/ClientApp/ContentView.swift
+++ b/client/Sources/ClientApp/ContentView.swift
@@ -1,0 +1,47 @@
+import SwiftUI
+
+struct Host: Identifiable, Hashable {
+    let id = UUID()
+    let name: String
+    let address: String
+}
+
+struct ContentView: View {
+    @EnvironmentObject var session: RemoteSession
+    @State private var selectedHost: Host?
+
+    var body: some View {
+        Group {
+            if session.connectionState == .connected {
+                ScreenShareView()
+            } else {
+                VStack {
+                    List(session.availableHosts, selection: $selectedHost) { host in
+                        Text(host.name).tag(host as Host?)
+                    }
+                    .frame(minHeight: 200)
+
+                    HStack {
+                        Button("Connect") {
+                            if let host = selectedHost {
+                                session.connect(to: host)
+                            }
+                        }
+                        .disabled(selectedHost == nil || session.isConnecting)
+
+                        Text(session.statusMessage)
+                            .foregroundColor(session.connectionState == .connected ? .green : .secondary)
+                    }
+                    .padding()
+                }
+            }
+        }
+        .frame(minWidth: 400, minHeight: 300)
+    }
+}
+
+struct ContentView_Previews: PreviewProvider {
+    static var previews: some View {
+        ContentView().environmentObject(RemoteSession())
+    }
+}

--- a/client/Sources/ClientApp/Networking.swift
+++ b/client/Sources/ClientApp/Networking.swift
@@ -1,0 +1,57 @@
+import Foundation
+
+/// Represents a remote access session brokered through a server.
+@MainActor
+final class RemoteSession: ObservableObject {
+    enum State {
+        case idle
+        case connecting
+        case connected
+        case failed(Error)
+    }
+
+    @Published var availableHosts: [Host] = [
+        Host(name: "Office Mac", address: "mac.example.com"),
+        Host(name: "Home iMac", address: "imac.example.com")
+    ]
+
+    @Published private(set) var connectionState: State = .idle
+
+    var isConnecting: Bool {
+        if case .connecting = connectionState { return true }
+        return false
+    }
+
+    var statusMessage: String {
+        switch connectionState {
+        case .idle: return "Not Connected"
+        case .connecting: return "Connecting..."
+        case .connected: return "Connected"
+        case .failed(let err): return "Failed: \(err.localizedDescription)"
+        }
+    }
+
+    /// Authenticate with the broker and establish a WebRTC/SSH tunnel.
+    func connect(to host: Host) {
+        connectionState = .connecting
+        Task {
+            do {
+                try await authenticate()
+                try await establishTunnel(to: host)
+                await MainActor.run { self.connectionState = .connected }
+            } catch {
+                await MainActor.run { self.connectionState = .failed(error) }
+            }
+        }
+    }
+
+    private func authenticate() async throws {
+        // TODO: Implement authentication with broker using secure credentials.
+        try await Task.sleep(nanoseconds: 500_000_000)
+    }
+
+    private func establishTunnel(to host: Host) async throws {
+        // TODO: Use WebRTC or SSH to create a secure tunnel to the host.
+        try await Task.sleep(nanoseconds: 500_000_000)
+    }
+}

--- a/client/Sources/ClientApp/PreferencesView.swift
+++ b/client/Sources/ClientApp/PreferencesView.swift
@@ -1,0 +1,29 @@
+import SwiftUI
+
+struct PreferencesView: View {
+    @AppStorage("publicKey") private var publicKey: String = ""
+    @AppStorage("autoReconnect") private var autoReconnect: Bool = true
+    @AppStorage("videoQuality") private var videoQuality: Double = 0.8
+
+    var body: some View {
+        Form {
+            Section(header: Text("Security")) {
+                TextField("SSH Public Key", text: $publicKey)
+                Toggle("Reconnect Automatically", isOn: $autoReconnect)
+            }
+            Section(header: Text("Quality")) {
+                Slider(value: $videoQuality, in: 0.1...1.0, step: 0.1) {
+                    Text("Video Quality")
+                }
+            }
+        }
+        .padding(20)
+        .frame(width: 400)
+    }
+}
+
+struct PreferencesView_Previews: PreviewProvider {
+    static var previews: some View {
+        PreferencesView()
+    }
+}

--- a/client/Sources/ClientApp/ScreenShareView.swift
+++ b/client/Sources/ClientApp/ScreenShareView.swift
@@ -1,0 +1,14 @@
+import SwiftUI
+import AVFoundation
+
+/// Placeholder view that would host the screen sharing content.
+struct ScreenShareView: View {
+    @EnvironmentObject var session: RemoteSession
+
+    var body: some View {
+        Rectangle()
+            .foregroundColor(.black)
+            .overlay(Text("Remote desktop would appear here")
+                .foregroundColor(.white))
+    }
+}


### PR DESCRIPTION
## Summary
- scaffold SwiftUI-based ClientApp with host list, connect button, and status messaging
- add networking layer stub for broker authentication and secure tunnel setup
- add screen sharing placeholder and preferences UI for key management and quality settings

## Testing
- `swift build` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_689b080d2c8c83298483bc7b96541e63