### PR TITLE
Add broker service for host registration and signaling

### DIFF
--- a/broker/.gitignore
+++ b/broker/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+.env

--- a/broker/README.md
+++ b/broker/README.md
@@ -1,0 +1,39 @@
+# Broker Service
+
+This service coordinates host registration and client connections, relaying WebRTC/SSH offers between peers.
+
+## Endpoints
+
+### REST
+- `POST /register` – register a host. Body: `{ "hostId": "optional" }`.
+- `POST /connect` – check if a host is available. Body: `{ "hostId": "id" }`.
+- `POST /keepalive` – refresh host presence. Body: `{ "hostId": "id" }`.
+
+### WebSocket
+- `ws://<host>:<port>/connect?hostId=<id>&role=host|client` – forwards messages between host and client.
+
+## Running locally
+1. Install dependencies: `npm install`.
+2. Start the server: `npm start`.
+3. Set `PORT` to choose the listening port (default `3000`).
+4. Optionally set `REDIS_URL` to persist host presence in Redis.
+
+## Self-hosted deployment
+1. Ensure Node.js 18+ is installed on the host.
+2. Clone the repository and run `npm install` inside the `broker` directory.
+3. Run `npm start` (or manage with a process manager like `pm2` or `systemd`).
+4. Optionally run a Redis instance and provide `REDIS_URL` to the service.
+
+## Cloud deployment
+1. Build a container image:
+   ```Dockerfile
+   FROM node:18-alpine
+   WORKDIR /app
+   COPY broker/package*.json ./
+   RUN npm install --only=production
+   COPY broker/ .
+   CMD ["node", "server.js"]
+   ```
+2. Push the image to your registry.
+3. Deploy to your preferred platform (Kubernetes, ECS, Cloud Run, etc.) exposing the desired port.
+4. Configure environment variables (`PORT`, `REDIS_URL`) via your platform.

--- a/broker/package.json
+++ b/broker/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "broker",
+  "version": "1.0.0",
+  "description": "Simple broker server for host registration and WebRTC/SSH offer relay",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js",
+    "test": "echo \"No tests specified\""
+  },
+  "dependencies": {
+    "express": "^4.19.2",
+    "ws": "^8.17.0",
+    "uuid": "^9.0.1",
+    "ioredis": "^5.3.2"
+  }
+}

--- a/broker/server.js
+++ b/broker/server.js
@@ -1,0 +1,97 @@
+const express = require('express');
+const http = require('http');
+const { WebSocketServer } = require('ws');
+const { v4: uuidv4 } = require('uuid');
+const Redis = require('ioredis');
+
+const app = express();
+app.use(express.json());
+
+// Presence store: in-memory Map or Redis hash
+const redisUrl = process.env.REDIS_URL;
+let presenceStore;
+if (redisUrl) {
+  const redis = new Redis(redisUrl);
+  presenceStore = {
+    async set(id, data) { await redis.hset('hosts', id, JSON.stringify(data)); },
+    async get(id) { const res = await redis.hget('hosts', id); return res ? JSON.parse(res) : null; },
+    async delete(id) { await redis.hdel('hosts', id); }
+  };
+} else {
+  const hosts = new Map();
+  presenceStore = {
+    async set(id, data) { hosts.set(id, data); },
+    async get(id) { return hosts.get(id); },
+    async delete(id) { hosts.delete(id); }
+  };
+}
+
+// Register host
+app.post('/register', async (req, res) => {
+  let { hostId } = req.body;
+  if (!hostId) hostId = uuidv4();
+  await presenceStore.set(hostId, { lastSeen: Date.now() });
+  res.json({ hostId });
+});
+
+// Keep host alive
+app.post('/keepalive', async (req, res) => {
+  const { hostId } = req.body;
+  if (!hostId) return res.status(400).json({ error: 'hostId required' });
+  const host = await presenceStore.get(hostId);
+  if (!host) return res.status(404).json({ error: 'host not found' });
+  host.lastSeen = Date.now();
+  await presenceStore.set(hostId, host);
+  res.json({ ok: true });
+});
+
+// Basic connect check via REST
+app.post('/connect', async (req, res) => {
+  const { hostId } = req.body;
+  if (!hostId) return res.status(400).json({ error: 'hostId required' });
+  const host = await presenceStore.get(hostId);
+  if (!host) return res.status(404).json({ error: 'host not found' });
+  res.json({ ok: true });
+});
+
+const server = http.createServer(app);
+
+// WebSocket for relaying offers
+const wss = new WebSocketServer({ server, path: '/connect' });
+const peers = new Map(); // hostId -> {host: ws, client: ws}
+
+wss.on('connection', (ws, req) => {
+  const url = new URL(req.url, `http://${req.headers.host}`);
+  const hostId = url.searchParams.get('hostId');
+  const role = url.searchParams.get('role');
+  if (!hostId || !role) {
+    ws.close();
+    return;
+  }
+  let pair = peers.get(hostId) || {};
+  pair[role] = ws;
+  peers.set(hostId, pair);
+
+  ws.on('message', (msg) => {
+    const target = pair[role === 'host' ? 'client' : 'host'];
+    if (target && target.readyState === target.OPEN) {
+      target.send(msg);
+    }
+  });
+
+  ws.on('close', () => {
+    const current = peers.get(hostId);
+    if (!current) return;
+    current[role] = null;
+    if (!current.host && !current.client) {
+      peers.delete(hostId);
+    } else {
+      peers.set(hostId, current);
+    }
+  });
+});
+
+const PORT = process.env.PORT || 3000;
+server.listen(PORT, () => {
+  console.log(`Broker listening on port ${PORT}`);
+});


### PR DESCRIPTION
## Summary
- add a Node.js broker server relaying WebRTC/SSH offers between hosts and clients
- provide REST endpoints for register, connect, and keepalive plus a WebSocket signaling channel
- document local, self-hosted, and cloud deployment steps

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/express)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689b08592c18832990ba4a457c47e3ae