### PR TITLE
Add AGENTS guidelines for contributors

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,10 +1,16 @@
 # AGENTS.md
 
 ## Code Style
-- Follow <your preferred style guide>, enforced with <linter/formatter>.
+- Use Prettier for JavaScript and TypeScript formatting.
+- Use ESLint with the repository's configuration to enforce consistency.
+- Prefer concise, descriptive names and keep functions focused.
 
 ## Testing
-- Run `npm test` before committing.
+- Run `npm test` in each affected Node package (e.g., `broker`) before committing.
+- Run `swift test` in the `client` package when Swift code changes.
+- Ensure all tests pass and address any failures.
 
 ## Pull Requests
-- Provide a brief summary of changes and reference issue numbers when applicable.
+- Provide a summary of changes and their rationale.
+- Include the tests executed and their results.
+- Keep commits focused and reference related issue numbers when applicable.


### PR DESCRIPTION
## Summary
- add repository-wide AGENTS instructions for style, testing, and PRs

## Testing
- `npm test` *(fails: could not read package.json)*
- `cd broker && npm test`
- `cd client && swift test` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_689b0c7177988329a2c4b8e31738ea5b