### PR TITLE
Add host agent auth payload tests and macOS CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,35 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18
+      - name: Install broker dependencies
+        run: |
+          cd broker
+          npm install
+      - name: Lint scripts
+        run: |
+          npx prettier --check scripts/client-handshake.js
+          npx eslint scripts/client-handshake.js
+      - name: Run broker tests
+        run: |
+          cd broker
+          npm test
+      - name: Test host agent
+        run: |
+          cd host-agent
+          swift test
+      - name: Test client
+        run: |
+          cd client
+          swift test

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,15 @@
+export default [
+  {
+    languageOptions: {
+      ecmaVersion: 2021,
+      sourceType: "commonjs",
+      globals: {
+        require: "readonly",
+        module: "readonly",
+        process: "readonly",
+        console: "readonly",
+      },
+    },
+    rules: {},
+  },
+];

--- a/host-agent/Package.swift
+++ b/host-agent/Package.swift
@@ -1,0 +1,21 @@
+// swift-tools-version:5.7
+import PackageDescription
+
+let package = Package(
+    name: "HostAgent",
+    platforms: [
+        .macOS(.v12)
+    ],
+    products: [
+        .executable(name: "HostAgent", targets: ["HostAgent"])
+    ],
+    targets: [
+        .executableTarget(
+            name: "HostAgent"
+        ),
+        .testTarget(
+            name: "HostAgentTests",
+            dependencies: ["HostAgent"]
+        )
+    ]
+)

--- a/host-agent/Sources/HostAgent/HostAgentCore.swift
+++ b/host-agent/Sources/HostAgent/HostAgentCore.swift
@@ -54,17 +54,13 @@ final class BrokerConnection {
     }
 
     private func authenticate(hostID: String, keyPath: String) {
-        guard let data = FileManager.default.contents(atPath: keyPath),
-              let key = String(data: data, encoding: .utf8) else {
+        guard let sendData = buildAuthPayload(hostID: hostID, keyPath: keyPath) else {
             NSLog("Unable to read key at \(keyPath)")
             return
         }
-        let payload: [String: String] = ["host_id": hostID, "key": key.trimmingCharacters(in: .whitespacesAndNewlines)]
-        if let sendData = try? JSONSerialization.data(withJSONObject: payload, options: []) {
-            task?.send(.data(sendData)) { error in
-                if let error = error {
-                    NSLog("Failed to send auth: \(error)")
-                }
+        task?.send(.data(sendData)) { error in
+            if let error = error {
+                NSLog("Failed to send auth: \(error)")
             }
         }
     }
@@ -87,6 +83,18 @@ final class BrokerConnection {
             self?.receive()
         }
     }
+}
+
+func buildAuthPayload(hostID: String, keyPath: String) -> Data? {
+    guard let data = FileManager.default.contents(atPath: keyPath),
+          let key = String(data: data, encoding: .utf8) else {
+        return nil
+    }
+    let payload: [String: String] = [
+        "host_id": hostID,
+        "key": key.trimmingCharacters(in: .whitespacesAndNewlines)
+    ]
+    return try? JSONSerialization.data(withJSONObject: payload, options: [])
 }
 
 func parseArguments() -> HostAgentConfig? {
@@ -121,21 +129,4 @@ func parseArguments() -> HostAgentConfig? {
 
     print("Usage: HostAgent --host-id <ID> --broker-url <URL> [--key-path <PATH>]")
     return nil
-}
-
-let signalSource = DispatchSource.makeSignalSource(signal: SIGTERM, queue: .main)
-signal(SIGTERM, SIG_IGN)
-signalSource.setEventHandler {
-    exit(0)
-}
-signalSource.resume()
-
-if let config = parseArguments() {
-    let monitor = RemoteManagementMonitor()
-    monitor.start()
-
-    let broker = BrokerConnection(url: config.brokerURL)
-    broker.connect(hostID: config.hostID, keyPath: config.keyPath)
-
-    RunLoop.current.run()
 }

--- a/host-agent/Sources/HostAgent/main.swift
+++ b/host-agent/Sources/HostAgent/main.swift
@@ -1,0 +1,19 @@
+import Foundation
+import Dispatch
+
+let signalSource = DispatchSource.makeSignalSource(signal: SIGTERM, queue: .main)
+signal(SIGTERM, SIG_IGN)
+signalSource.setEventHandler {
+    exit(0)
+}
+signalSource.resume()
+
+if let config = parseArguments() {
+    let monitor = RemoteManagementMonitor()
+    monitor.start()
+
+    let broker = BrokerConnection(url: config.brokerURL)
+    broker.connect(hostID: config.hostID, keyPath: config.keyPath)
+
+    RunLoop.current.run()
+}

--- a/host-agent/Tests/HostAgentTests/HostAgentTests.swift
+++ b/host-agent/Tests/HostAgentTests/HostAgentTests.swift
@@ -1,0 +1,64 @@
+import XCTest
+@testable import HostAgent
+
+final class HostAgentTests: XCTestCase {
+    func testParseArgumentsParsesAllRequiredOptions() throws {
+        let tmpDir = FileManager.default.temporaryDirectory
+        let keyFile = tmpDir.appendingPathComponent("host_key.pub")
+        try "TEST_KEY".write(to: keyFile, atomically: true, encoding: .utf8)
+
+        CommandLine.arguments = [
+            "HostAgent",
+            "--host-id", "123",
+            "--broker-url", "ws://localhost:3000",
+            "--key-path", keyFile.path
+        ]
+
+        guard let config = parseArguments() else {
+            XCTFail("parseArguments returned nil")
+            return
+        }
+        XCTAssertEqual(config.hostID, "123")
+        XCTAssertEqual(config.brokerURL, URL(string: "ws://localhost:3000"))
+        XCTAssertEqual(config.keyPath, keyFile.path)
+    }
+
+    func testParseArgumentsUsesDefaultKeyPath() {
+        CommandLine.arguments = [
+            "HostAgent",
+            "--host-id", "abc",
+            "--broker-url", "ws://example.com"
+        ]
+        let config = parseArguments()
+        XCTAssertNotNil(config)
+        let expected = FileManager.default
+            .homeDirectoryForCurrentUser
+            .appendingPathComponent(".ds-vnc/keys/host_key.pub")
+            .path
+        XCTAssertEqual(config?.keyPath, expected)
+    }
+
+    func testParseArgumentsMissingRequired() {
+        CommandLine.arguments = ["HostAgent", "--broker-url", "ws://example.com"]
+        XCTAssertNil(parseArguments())
+    }
+
+    func testBuildAuthPayloadCreatesJSON() throws {
+        let tmpDir = FileManager.default.temporaryDirectory
+        let keyFile = tmpDir.appendingPathComponent("host_key.pub")
+        try "my-key\n".write(to: keyFile, atomically: true, encoding: .utf8)
+
+        guard let data = buildAuthPayload(hostID: "abc", keyPath: keyFile.path) else {
+            XCTFail("Expected payload data")
+            return
+        }
+        let obj = try JSONSerialization.jsonObject(with: data) as? [String: String]
+        XCTAssertEqual(obj?["host_id"], "abc")
+        XCTAssertEqual(obj?["key"], "my-key")
+    }
+
+    func testBuildAuthPayloadMissingKeyFile() {
+        let data = buildAuthPayload(hostID: "abc", keyPath: "/nonexistent")
+        XCTAssertNil(data)
+    }
+}

--- a/scripts/client-handshake.js
+++ b/scripts/client-handshake.js
@@ -1,0 +1,34 @@
+const WebSocket = require("../broker/node_modules/ws");
+
+const url = process.argv[2];
+if (!url) {
+  console.error("Usage: node client-handshake.js <ws-url>");
+  process.exit(1);
+}
+
+const ws = new WebSocket(url);
+
+ws.on("open", () => {
+  console.log("Client connected");
+});
+
+ws.on("message", (data) => {
+  const msg = data.toString();
+  console.log("Received:", msg);
+  if (msg.includes("host_id")) {
+    ws.send("ack");
+    ws.close();
+  } else {
+    console.error("Unexpected message");
+    process.exit(1);
+  }
+});
+
+ws.on("close", () => {
+  process.exit(0);
+});
+
+ws.on("error", (err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/e2e-handshake.sh
+++ b/scripts/e2e-handshake.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+set -euo pipefail
+
+HOST_ID="test-host-$$"
+BROKER_PORT=3000
+BROKER_URL="ws://localhost:${BROKER_PORT}/connect?hostId=${HOST_ID}&role=host"
+CLIENT_URL="ws://localhost:${BROKER_PORT}/connect?hostId=${HOST_ID}&role=client"
+
+KEY_DIR=$(mktemp -d)
+KEY_PATH="$KEY_DIR/host_key.pub"
+echo "dummy-key" > "$KEY_PATH"
+
+# Start broker
+node broker/server.js &
+BROKER_PID=$!
+
+# Start host agent
+(
+  cd host-agent && swift run HostAgent --host-id "$HOST_ID" --broker-url "$BROKER_URL" --key-path "$KEY_PATH"
+) &
+HOST_PID=$!
+
+# Allow processes to start
+sleep 2
+
+# Run client handshake check
+node scripts/client-handshake.js "$CLIENT_URL"
+RESULT=$?
+
+# Cleanup
+kill $HOST_PID $BROKER_PID
+rm -rf "$KEY_DIR"
+
+exit $RESULT


### PR DESCRIPTION
## Summary
- add `buildAuthPayload` helper and test coverage for host agent
- configure ESLint and GitHub Actions CI on macOS

## Testing
- `npx prettier -w eslint.config.js scripts/client-handshake.js`
- `npx eslint scripts/client-handshake.js`
- `cd broker && npm test`
- `cd host-agent && swift test`
- `cd client && swift test` *(fails: no such module 'SwiftUI')*
- `bash scripts/e2e-handshake.sh` *(fails: WebSockets not supported by libcurl)*

------
https://chatgpt.com/codex/tasks/task_e_689b0f6e21c48329b3373ae45768df32