### PR TITLE
chore: upgrade to Swift 6.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Prototype repository for building a macOS remote access tool.
 
+Swift components require Swift 6.1 or later.
+
 ## Architecture
 
 ```mermaid

--- a/client/Package.swift
+++ b/client/Package.swift
@@ -19,5 +19,6 @@ let package = Package(
             name: "ClientApp",
             dependencies: []
         )
-    ]
+    ],
+    swiftLanguageModes: [.v6]
 )

--- a/docs/client_usage.md
+++ b/docs/client_usage.md
@@ -16,7 +16,7 @@ sequenceDiagram
 ## Installation
 
 1. Navigate to the `client` directory.
-2. Build the Swift package:
+2. Build the Swift 6.1 package:
    ```bash
    swift build
    ```

--- a/host-agent/Package.swift
+++ b/host-agent/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:6.1
+// swift-tools-version: 6.1
 import PackageDescription
 
 let package = Package(
@@ -9,6 +9,7 @@ let package = Package(
     products: [
         .executable(name: "HostAgent", targets: ["HostAgent"])
     ],
+    dependencies: [],
     targets: [
         .executableTarget(
             name: "HostAgent"
@@ -17,5 +18,6 @@ let package = Package(
             name: "HostAgentTests",
             dependencies: ["HostAgent"]
         )
-    ]
+    ],
+    swiftLanguageModes: [.v6]
 )

--- a/host-agent/Sources/HostAgent/HostAgentCore.swift
+++ b/host-agent/Sources/HostAgent/HostAgentCore.swift
@@ -10,7 +10,7 @@ struct HostAgentConfig {
     let keyPath: String
 }
 
-final class RemoteManagementMonitor {
+final class RemoteManagementMonitor: @unchecked Sendable {
     private var timer: Timer?
     private let interval: TimeInterval = 60
 
@@ -36,7 +36,7 @@ final class RemoteManagementMonitor {
     }
 }
 
-final class BrokerConnection {
+final class BrokerConnection: @unchecked Sendable {
     private let url: URL
     private let session: URLSession
     private var task: URLSessionWebSocketTask?
@@ -97,12 +97,12 @@ func buildAuthPayload(hostID: String, keyPath: String) -> Data? {
     return try? JSONSerialization.data(withJSONObject: payload, options: [])
 }
 
-func parseArguments() -> HostAgentConfig? {
+func parseArguments(_ arguments: [String] = CommandLine.arguments) -> HostAgentConfig? {
     var hostID: String?
     var brokerURL: URL?
     var keyPath: String?
 
-    var iterator = CommandLine.arguments.dropFirst().makeIterator()
+    var iterator = arguments.dropFirst().makeIterator()
     while let arg = iterator.next() {
         switch arg {
         case "--host-id":

--- a/host-agent/Tests/HostAgentTests/HostAgentTests.swift
+++ b/host-agent/Tests/HostAgentTests/HostAgentTests.swift
@@ -7,14 +7,14 @@ final class HostAgentTests: XCTestCase {
         let keyFile = tmpDir.appendingPathComponent("host_key.pub")
         try "TEST_KEY".write(to: keyFile, atomically: true, encoding: .utf8)
 
-        CommandLine.arguments = [
+        let args = [
             "HostAgent",
             "--host-id", "123",
             "--broker-url", "ws://localhost:3000",
             "--key-path", keyFile.path
         ]
 
-        guard let config = parseArguments() else {
+        guard let config = parseArguments(args) else {
             XCTFail("parseArguments returned nil")
             return
         }
@@ -24,12 +24,12 @@ final class HostAgentTests: XCTestCase {
     }
 
     func testParseArgumentsUsesDefaultKeyPath() {
-        CommandLine.arguments = [
+        let args = [
             "HostAgent",
             "--host-id", "abc",
             "--broker-url", "ws://example.com"
         ]
-        let config = parseArguments()
+        let config = parseArguments(args)
         XCTAssertNotNil(config)
         let expected = FileManager.default
             .homeDirectoryForCurrentUser
@@ -39,8 +39,8 @@ final class HostAgentTests: XCTestCase {
     }
 
     func testParseArgumentsMissingRequired() {
-        CommandLine.arguments = ["HostAgent", "--broker-url", "ws://example.com"]
-        XCTAssertNil(parseArguments())
+        let args = ["HostAgent", "--broker-url", "ws://example.com"]
+        XCTAssertNil(parseArguments(args))
     }
   
     func testBuildAuthPayloadCreatesJSON() throws {


### PR DESCRIPTION
## Summary
- target Swift 6.1 in package manifests
- conform HostAgent types to `Sendable` and update argument parsing for Swift 6
- document Swift 6.1 requirement

## Testing
- `swift test` (host-agent)
- `swift test` (client) *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_689b4be839548329b71de34688bef275